### PR TITLE
Implement +7 scoring rule for The Jerome

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)"
+    ]
+  }
+}

--- a/app/admin/teams/[id]/edit/page.tsx
+++ b/app/admin/teams/[id]/edit/page.tsx
@@ -5,6 +5,7 @@ import { useSession } from "next-auth/react";
 import { useRouter, useParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -25,6 +26,7 @@ type Round = {
 type Team = {
   id: number;
   name: string;
+  seed: number | null;
   roundId: number;
   isEliminated: boolean;
   tournament: { id: number; name: string } | null;
@@ -38,6 +40,7 @@ export default function EditTeamPage() {
   const [team, setTeam] = useState<Team | null>(null);
   const [rounds, setRounds] = useState<Round[]>([]);
   const [selectedRoundId, setSelectedRoundId] = useState("");
+  const [seed, setSeed] = useState<string>("");
   const [isEliminated, setIsEliminated] = useState(false);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -71,6 +74,7 @@ export default function EditTeamPage() {
 
       setTeam(found);
       setSelectedRoundId(String(found.roundId));
+      setSeed(found.seed != null ? String(found.seed) : "");
       setIsEliminated(found.isEliminated);
       setRounds(data.rounds || []);
     } catch (err) {
@@ -97,6 +101,7 @@ export default function EditTeamPage() {
         body: JSON.stringify({
           teamId: parseInt(params.id as string),
           roundId: parseInt(selectedRoundId),
+          seed: seed === "" ? null : parseInt(seed),
           isEliminated,
         }),
       });
@@ -163,6 +168,18 @@ export default function EditTeamPage() {
                   ))}
               </SelectContent>
             </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="seed">Seed</Label>
+            <Input
+              id="seed"
+              type="number"
+              min="1"
+              value={seed}
+              onChange={(e) => setSeed(e.target.value)}
+              placeholder="e.g. 1, 2, 3..."
+            />
           </div>
 
           <div className="flex items-center space-x-2">

--- a/app/admin/tournaments/page.tsx
+++ b/app/admin/tournaments/page.tsx
@@ -106,9 +106,9 @@ function MobileTournamentCard({
               <Button size="sm" variant="outline" onClick={onEdit} className="flex-1">
                 Edit Time
               </Button>
-              <Link href={`/tournaments/${tournament.id}`} className="flex-1">
+              <Link href={`/admin/tournaments/${tournament.id}/teams`} className="flex-1">
                 <Button size="sm" variant="outline" className="w-full">
-                  View Teams
+                  Manage Teams
                 </Button>
               </Link>
             </div>
@@ -345,10 +345,10 @@ export default function AdminTournamentsPage() {
                   </TableCell>
                   <TableCell>
                     <Link
-                      href={`/tournaments/${tournament.id}`}
+                      href={`/admin/tournaments/${tournament.id}/teams`}
                       className="text-sm underline hover:text-primary"
                     >
-                      View
+                      Manage Teams
                     </Link>
                   </TableCell>
                   <TableCell>

--- a/app/api/admin/teams/route.ts
+++ b/app/api/admin/teams/route.ts
@@ -44,7 +44,7 @@ export async function PATCH(request: NextRequest) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    const { teamId, roundId, isEliminated } = await request.json();
+    const { teamId, roundId, isEliminated, seed } = await request.json();
 
     if (!teamId) {
       return NextResponse.json(
@@ -53,9 +53,10 @@ export async function PATCH(request: NextRequest) {
       );
     }
 
-    const updateData: { roundId?: number; isEliminated?: boolean } = {};
+    const updateData: { roundId?: number; isEliminated?: boolean; seed?: number | null } = {};
     if (roundId !== undefined) updateData.roundId = roundId;
     if (isEliminated !== undefined) updateData.isEliminated = isEliminated;
+    if (seed !== undefined) updateData.seed = seed;
 
     if (Object.keys(updateData).length === 0) {
       return NextResponse.json(

--- a/app/api/admin/tournaments/route.ts
+++ b/app/api/admin/tournaments/route.ts
@@ -43,21 +43,30 @@ export async function PATCH(request: NextRequest) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    const { tournamentId, startsAt, endsAt } = await request.json();
+    const { tournamentId, startsAt, endsAt, isNeutralSite } = await request.json();
 
-    if (!tournamentId || !startsAt || !endsAt) {
+    if (!tournamentId) {
       return NextResponse.json(
-        { error: "Tournament ID, start time, and end time are required" },
+        { error: "Tournament ID is required" },
+        { status: 400 }
+      );
+    }
+
+    const updateData: { startsAt?: Date; endsAt?: Date; isNeutralSite?: boolean } = {};
+    if (startsAt !== undefined) updateData.startsAt = new Date(startsAt);
+    if (endsAt !== undefined) updateData.endsAt = new Date(endsAt);
+    if (isNeutralSite !== undefined) updateData.isNeutralSite = isNeutralSite;
+
+    if (Object.keys(updateData).length === 0) {
+      return NextResponse.json(
+        { error: "No fields to update" },
         { status: 400 }
       );
     }
 
     const [updated] = await db
       .update(tournaments)
-      .set({
-        startsAt: new Date(startsAt),
-        endsAt: new Date(endsAt),
-      })
+      .set(updateData)
       .where(eq(tournaments.id, tournamentId))
       .returning();
 

--- a/app/api/leaders/route.ts
+++ b/app/api/leaders/route.ts
@@ -8,6 +8,7 @@ import {
   teams,
   rounds,
   users,
+  tournaments,
 } from "@/lib/db/schema";
 import { calculateEntryScore } from "@/lib/utils/scoring";
 import { calculatePPR } from "@/lib/utils/ppr";
@@ -35,6 +36,7 @@ export async function GET() {
     const allTeams = await db.select().from(teams);
     const allRounds = await db.select().from(rounds);
     const allUsers = await db.select().from(users);
+    const allTournaments = await db.select().from(tournaments);
 
     // Build lookups
     const usersById = new Map(allUsers.map((u) => [u.id, u]));
@@ -49,8 +51,8 @@ export async function GET() {
     // Calculate scores and PPR for each entry
     const leaderboard = allEntries.map((entry) => {
       const entryPicks = picksByEntry.get(entry.id) || [];
-      const score = calculateEntryScore(entryPicks, allTeams, allRounds);
-      const ppr = calculatePPR(score, entryPicks, allTeams, allRounds);
+      const score = calculateEntryScore(entryPicks, allTeams, allRounds, allTournaments);
+      const ppr = calculatePPR(score, entryPicks, allTeams, allRounds, allTournaments);
       const user = usersById.get(entry.userId);
 
       return {

--- a/app/components/EntryForm.tsx
+++ b/app/components/EntryForm.tsx
@@ -19,6 +19,7 @@ import { Lock } from "lucide-react";
 type Team = {
   id: number;
   name: string;
+  seed: number | null;
   tournamentId: number;
   roundId: number;
   isEliminated: boolean;
@@ -217,6 +218,7 @@ export default function EntryForm() {
                     <SelectContent>
                       {tournament.teams.map((team) => (
                         <SelectItem key={team.id} value={String(team.id)}>
+                          {team.seed != null ? `(${team.seed}) ` : ""}
                           {team.name}
                         </SelectItem>
                       ))}

--- a/app/tournaments/[id]/page.tsx
+++ b/app/tournaments/[id]/page.tsx
@@ -66,7 +66,7 @@ export default function TournamentDetailPage() {
 
       if (!found) {
         setError("Tournament not found");
-      } else if (!found.locked) {
+      } else if (!found.locked && !session?.user.isAdmin) {
         setError("Tournament hasn't started yet");
       } else {
         setTournament(found);

--- a/app/tournaments/[id]/page.tsx
+++ b/app/tournaments/[id]/page.tsx
@@ -16,6 +16,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 type Team = {
   id: number;
   name: string;
+  seed: number | null;
   isEliminated: boolean;
   round: { id: number; name: string; order: number; points: number } | null;
 };
@@ -147,7 +148,10 @@ export default function TournamentDetailPage() {
                 <TableBody>
                   {teams.map((team) => (
                     <TableRow key={team.id}>
-                      <TableCell className="font-medium">{team.name}</TableCell>
+                      <TableCell className="font-medium">
+                        {team.seed != null ? `(${team.seed}) ` : ""}
+                        {team.name}
+                      </TableCell>
                       <TableCell>
                         {team.isEliminated ? (
                           <Badge variant="destructive">Eliminated</Badge>

--- a/app/tournaments/[id]/page.tsx
+++ b/app/tournaments/[id]/page.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useParams } from "next/navigation";
+import { useSession } from "next-auth/react";
+import Link from "next/link";
 import {
   Table,
   TableBody,
@@ -44,6 +46,7 @@ function MobileTeamRow({ team }: { team: Team }) {
 
 export default function TournamentDetailPage() {
   const params = useParams();
+  const { data: session } = useSession();
   const [tournament, setTournament] = useState<Tournament | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -143,6 +146,7 @@ export default function TournamentDetailPage() {
                   <TableRow>
                     <TableHead>Team</TableHead>
                     <TableHead>Status</TableHead>
+                    {session?.user.isAdmin && <TableHead>Actions</TableHead>}
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -159,6 +163,16 @@ export default function TournamentDetailPage() {
                           <Badge variant="secondary">Active</Badge>
                         )}
                       </TableCell>
+                      {session?.user.isAdmin && (
+                        <TableCell>
+                          <Link
+                            href={`/admin/teams/${team.id}/edit`}
+                            className="text-sm underline hover:text-primary"
+                          >
+                            Edit
+                          </Link>
+                        </TableCell>
+                      )}
                     </TableRow>
                   ))}
                 </TableBody>

--- a/drizzle/0001_good_ikaris.sql
+++ b/drizzle/0001_good_ikaris.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "teams" ADD COLUMN "seed" integer;--> statement-breakpoint
+ALTER TABLE "tournaments" ADD COLUMN "is_neutral_site" boolean DEFAULT false NOT NULL;

--- a/drizzle/0001_lonely_nicolaos.sql
+++ b/drizzle/0001_lonely_nicolaos.sql
@@ -1,8 +1,0 @@
--- Add ends_at column as nullable first
-ALTER TABLE "tournaments" ADD COLUMN "ends_at" timestamp;
-
--- Set default value for existing rows (start + 7 days)
-UPDATE "tournaments" SET "ends_at" = "starts_at" + INTERVAL '7 days' WHERE "ends_at" IS NULL;
-
--- Make the column NOT NULL after setting values
-ALTER TABLE "tournaments" ALTER COLUMN "ends_at" SET NOT NULL;

--- a/drizzle/0002_light_invaders.sql
+++ b/drizzle/0002_light_invaders.sql
@@ -1,0 +1,20 @@
+-- Add ends_at column only if it doesn't exist
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'tournaments' AND column_name = 'ends_at'
+  ) THEN
+    ALTER TABLE "tournaments" ADD COLUMN "ends_at" timestamp;
+    UPDATE "tournaments" SET "ends_at" = "starts_at" + INTERVAL '7 days' WHERE "ends_at" IS NULL;
+    ALTER TABLE "tournaments" ALTER COLUMN "ends_at" SET NOT NULL;
+  ELSE
+    -- Column already exists, just ensure existing rows have values
+    UPDATE "tournaments" SET "ends_at" = "starts_at" + INTERVAL '7 days' WHERE "ends_at" IS NULL;
+    -- Ensure it's NOT NULL
+    ALTER TABLE "tournaments" ALTER COLUMN "ends_at" SET NOT NULL;
+  END IF;
+END $$;--> statement-breakpoint
+-- Add unique constraints
+ALTER TABLE "teams" ADD CONSTRAINT "teams_name_tournament_unique" UNIQUE("name","tournament_id");--> statement-breakpoint
+ALTER TABLE "tournaments" ADD CONSTRAINT "tournaments_name_year_unique" UNIQUE("name","year_id");

--- a/drizzle/0002_thick_bushwacker.sql
+++ b/drizzle/0002_thick_bushwacker.sql
@@ -1,2 +1,0 @@
-ALTER TABLE "teams" ADD CONSTRAINT "teams_name_tournament_unique" UNIQUE("name","tournament_id");--> statement-breakpoint
-ALTER TABLE "tournaments" ADD CONSTRAINT "tournaments_name_year_unique" UNIQUE("name","year_id");

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "38d6cebd-8da5-4d0e-b395-4c9e948c54f0",
-  "prevId": "999f8ea7-61c3-4462-842c-c904472d83cc",
+  "id": "5ebb0bd5-3138-4818-9709-9bc0687fee66",
+  "prevId": "964b0a7a-8c40-4a0e-97e4-76428dc9df69",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -239,6 +239,12 @@
           "primaryKey": false,
           "notNull": true
         },
+        "seed": {
+          "name": "seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
         "tournament_id": {
           "name": "tournament_id",
           "type": "integer",
@@ -289,16 +295,7 @@
         }
       },
       "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "teams_name_tournament_unique": {
-          "name": "teams_name_tournament_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "name",
-            "tournament_id"
-          ]
-        }
-      },
+      "uniqueConstraints": {},
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
@@ -331,6 +328,13 @@
           "primaryKey": false,
           "notNull": true
         },
+        "is_neutral_site": {
+          "name": "is_neutral_site",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
         "year_id": {
           "name": "year_id",
           "type": "integer",
@@ -355,16 +359,7 @@
         }
       },
       "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "tournaments_name_year_unique": {
-          "name": "tournaments_name_year_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "name",
-            "year_id"
-          ]
-        }
-      },
+      "uniqueConstraints": {},
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "964b0a7a-8c40-4a0e-97e4-76428dc9df69",
-  "prevId": "762dee90-75be-4f36-8501-9d30611faa44",
+  "id": "372a665f-3fdd-4282-9dc1-d03b85d38076",
+  "prevId": "5ebb0bd5-3138-4818-9709-9bc0687fee66",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -295,7 +295,16 @@
         }
       },
       "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
+      "uniqueConstraints": {
+        "teams_name_tournament_unique": {
+          "name": "teams_name_tournament_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "tournament_id"
+          ]
+        }
+      },
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
@@ -318,6 +327,12 @@
         },
         "starts_at": {
           "name": "starts_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
           "type": "timestamp",
           "primaryKey": false,
           "notNull": true
@@ -353,7 +368,16 @@
         }
       },
       "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
+      "uniqueConstraints": {
+        "tournaments_name_year_unique": {
+          "name": "tournaments_name_year_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "year_id"
+          ]
+        }
+      },
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -12,15 +12,15 @@
     {
       "idx": 1,
       "version": "7",
-      "when": 1771126927496,
-      "tag": "0001_lonely_nicolaos",
+      "when": 1771471449407,
+      "tag": "0001_good_ikaris",
       "breakpoints": true
     },
     {
       "idx": 2,
       "version": "7",
-      "when": 1771551868603,
-      "tag": "0002_thick_bushwacker",
+      "when": 1771551242582,
+      "tag": "0002_light_invaders",
       "breakpoints": true
     }
   ]

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -58,6 +58,7 @@ export const tournaments = pgTable(
     name: varchar("name", { length: 255 }).notNull(),
     startsAt: timestamp("starts_at", { mode: "date" }).notNull(),
     endsAt: timestamp("ends_at", { mode: "date" }).notNull(),
+    isNeutralSite: boolean("is_neutral_site").notNull().default(false),
     yearId: integer("year_id")
       .notNull()
       .references(() => years.id),
@@ -78,6 +79,7 @@ export const teams = pgTable(
   {
     id: serial("id").primaryKey(),
     name: varchar("name", { length: 255 }).notNull(),
+    seed: integer("seed"),
     tournamentId: integer("tournament_id")
       .notNull()
       .references(() => tournaments.id),

--- a/lib/utils/ppr.ts
+++ b/lib/utils/ppr.ts
@@ -1,4 +1,4 @@
-import type { Team, Round } from "@/lib/db/schema";
+import type { Team, Round, Tournament } from "@/lib/db/schema";
 import { createScore, type Score } from "./scoring";
 
 export type PPR = number & { readonly __brand: "PPR" };
@@ -10,12 +10,14 @@ export function createPPR(value: number): PPR {
 /**
  * Calculate Points Possible Remaining for an entry.
  * PPR = current score + max possible points from non-eliminated picked teams.
+ * Teams eligible for the +7 bonus (not top-2 seed + neutral site) have a max of 7.
  */
 export function calculatePPR(
   currentScore: Score,
   picks: Array<{ teamId: number }>,
-  teams: Array<Pick<Team, "id" | "isEliminated">>,
-  rounds: Array<Pick<Round, "id" | "points" | "order">>
+  teams: Array<Pick<Team, "id" | "isEliminated" | "seed" | "tournamentId">>,
+  rounds: Array<Pick<Round, "id" | "points" | "order">>,
+  tournaments?: Array<Pick<Tournament, "id" | "isNeutralSite">>
 ): PPR {
   const maxRound = rounds.reduce(
     (max, r) => (r.points > max.points ? r : max),
@@ -26,8 +28,15 @@ export function calculatePPR(
   for (const pick of picks) {
     const team = teams.find((t) => t.id === pick.teamId);
     if (!team || team.isEliminated) continue;
-    // Non-eliminated team could still reach the highest-scoring round
-    maxRemaining += maxRound.points;
+
+    // Check if this team could earn the +7 bonus
+    const tournament = tournaments?.find((t) => t.id === team.tournamentId);
+    const canGetBonus =
+      team.seed != null &&
+      team.seed > 2 &&
+      tournament?.isNeutralSite === true;
+
+    maxRemaining += canGetBonus ? 7 : maxRound.points;
   }
 
   return createPPR(currentScore + maxRemaining);

--- a/lib/utils/scoring.ts
+++ b/lib/utils/scoring.ts
@@ -1,4 +1,4 @@
-import type { Team, Round } from "@/lib/db/schema";
+import type { Team, Round, Tournament } from "@/lib/db/schema";
 
 export type Score = number & { readonly __brand: "Score" };
 
@@ -7,24 +7,46 @@ export function createScore(value: number): Score {
 }
 
 export function calculatePickScore(
-  team: Pick<Team, "roundId">,
-  rounds: Pick<Round, "id" | "points">[]
+  team: Pick<Team, "roundId" | "seed" | "tournamentId">,
+  rounds: Pick<Round, "id" | "points">[],
+  tournaments?: Array<Pick<Tournament, "id" | "isNeutralSite">>
 ): Score {
   const round = rounds.find((r) => r.id === team.roundId);
   if (!round) return createScore(0);
-  return createScore(round.points);
+
+  const baseScore = round.points;
+
+  // +7 bonus: team won championship + not a top-2 seed + neutral site tournament
+  const championRound = rounds.reduce(
+    (max, r) => (r.points > max.points ? r : max),
+    rounds[0]
+  );
+  if (
+    round.id === championRound.id &&
+    championRound.points > 0 &&
+    team.seed != null &&
+    team.seed > 2
+  ) {
+    const tournament = tournaments?.find((t) => t.id === team.tournamentId);
+    if (tournament?.isNeutralSite) {
+      return createScore(7);
+    }
+  }
+
+  return createScore(baseScore);
 }
 
 export function calculateEntryScore(
   picks: Array<{ teamId: number }>,
-  teams: Array<Pick<Team, "id" | "roundId">>,
-  rounds: Array<Pick<Round, "id" | "points">>
+  teams: Array<Pick<Team, "id" | "roundId" | "seed" | "tournamentId">>,
+  rounds: Array<Pick<Round, "id" | "points">>,
+  tournaments?: Array<Pick<Tournament, "id" | "isNeutralSite">>
 ): Score {
   let total = 0;
   for (const pick of picks) {
     const team = teams.find((t) => t.id === pick.teamId);
     if (!team) continue;
-    total += calculatePickScore(team, rounds);
+    total += calculatePickScore(team, rounds, tournaments);
   }
   return createScore(total);
 }

--- a/tests/scoring.test.ts
+++ b/tests/scoring.test.ts
@@ -16,31 +16,82 @@ const rounds = [
 
 describe("calculatePickScore", () => {
   it("returns 0 for early round teams", () => {
-    expect(calculatePickScore({ roundId: 1 }, rounds)).toBe(0);
-    expect(calculatePickScore({ roundId: 2 }, rounds)).toBe(0);
-    expect(calculatePickScore({ roundId: 3 }, rounds)).toBe(0);
-    expect(calculatePickScore({ roundId: 4 }, rounds)).toBe(0);
+    expect(calculatePickScore({ roundId: 1, seed: null, tournamentId: 1 }, rounds)).toBe(0);
+    expect(calculatePickScore({ roundId: 2, seed: null, tournamentId: 1 }, rounds)).toBe(0);
+    expect(calculatePickScore({ roundId: 3, seed: null, tournamentId: 1 }, rounds)).toBe(0);
+    expect(calculatePickScore({ roundId: 4, seed: null, tournamentId: 1 }, rounds)).toBe(0);
   });
 
   it("returns 2 for finals teams", () => {
-    expect(calculatePickScore({ roundId: 5 }, rounds)).toBe(2);
+    expect(calculatePickScore({ roundId: 5, seed: null, tournamentId: 1 }, rounds)).toBe(2);
   });
 
   it("returns 5 for champion teams", () => {
-    expect(calculatePickScore({ roundId: 6 }, rounds)).toBe(5);
+    expect(calculatePickScore({ roundId: 6, seed: null, tournamentId: 1 }, rounds)).toBe(5);
   });
 
   it("returns 0 for unknown round", () => {
-    expect(calculatePickScore({ roundId: 99 }, rounds)).toBe(0);
+    expect(calculatePickScore({ roundId: 99, seed: null, tournamentId: 1 }, rounds)).toBe(0);
+  });
+
+  it("returns 7 for champion team that is not top-2 seed at neutral site", () => {
+    const tournaments = [{ id: 1, isNeutralSite: true }];
+    expect(
+      calculatePickScore({ roundId: 6, seed: 3, tournamentId: 1 }, rounds, tournaments)
+    ).toBe(7);
+  });
+
+  it("returns 7 for champion team with high seed number at neutral site", () => {
+    const tournaments = [{ id: 1, isNeutralSite: true }];
+    expect(
+      calculatePickScore({ roundId: 6, seed: 10, tournamentId: 1 }, rounds, tournaments)
+    ).toBe(7);
+  });
+
+  it("returns 5 for champion team that is a top-2 seed at neutral site", () => {
+    const tournaments = [{ id: 1, isNeutralSite: true }];
+    expect(
+      calculatePickScore({ roundId: 6, seed: 1, tournamentId: 1 }, rounds, tournaments)
+    ).toBe(5);
+    expect(
+      calculatePickScore({ roundId: 6, seed: 2, tournamentId: 1 }, rounds, tournaments)
+    ).toBe(5);
+  });
+
+  it("returns 5 for champion team not at neutral site regardless of seed", () => {
+    const tournaments = [{ id: 1, isNeutralSite: false }];
+    expect(
+      calculatePickScore({ roundId: 6, seed: 5, tournamentId: 1 }, rounds, tournaments)
+    ).toBe(5);
+  });
+
+  it("returns 5 for champion team with no seed set at neutral site", () => {
+    const tournaments = [{ id: 1, isNeutralSite: true }];
+    expect(
+      calculatePickScore({ roundId: 6, seed: null, tournamentId: 1 }, rounds, tournaments)
+    ).toBe(5);
+  });
+
+  it("returns 5 for champion team when no tournaments provided", () => {
+    expect(
+      calculatePickScore({ roundId: 6, seed: 5, tournamentId: 1 }, rounds)
+    ).toBe(5);
+  });
+
+  it("does not apply +7 bonus to non-champion rounds", () => {
+    const tournaments = [{ id: 1, isNeutralSite: true }];
+    expect(
+      calculatePickScore({ roundId: 5, seed: 5, tournamentId: 1 }, rounds, tournaments)
+    ).toBe(2);
   });
 });
 
 describe("calculateEntryScore", () => {
   const teams = [
-    { id: 1, roundId: 6 }, // Champion = 5
-    { id: 2, roundId: 5 }, // Finals = 2
-    { id: 3, roundId: 1 }, // Round 1 = 0
-    { id: 4, roundId: 3 }, // Round 3 = 0
+    { id: 1, roundId: 6, seed: null, tournamentId: 1 }, // Champion = 5
+    { id: 2, roundId: 5, seed: null, tournamentId: 1 }, // Finals = 2
+    { id: 3, roundId: 1, seed: null, tournamentId: 1 }, // Round 1 = 0
+    { id: 4, roundId: 3, seed: null, tournamentId: 1 }, // Round 3 = 0
   ];
 
   it("calculates total score across all picks", () => {
@@ -64,10 +115,21 @@ describe("calculateEntryScore", () => {
 
   it("correctly sums multiple champion picks", () => {
     const multiChampionTeams = [
-      { id: 1, roundId: 6 },
-      { id: 2, roundId: 6 },
+      { id: 1, roundId: 6, seed: null, tournamentId: 1 },
+      { id: 2, roundId: 6, seed: null, tournamentId: 2 },
     ];
     const picks = [{ teamId: 1 }, { teamId: 2 }];
     expect(calculateEntryScore(picks, multiChampionTeams, rounds)).toBe(10);
+  });
+
+  it("applies +7 bonus in entry score calculation", () => {
+    const bonusTeams = [
+      { id: 1, roundId: 6, seed: 5, tournamentId: 1 }, // Champion, seed 5, neutral = 7
+      { id: 2, roundId: 6, seed: 1, tournamentId: 1 }, // Champion, seed 1, neutral = 5
+      { id: 3, roundId: 5, seed: 3, tournamentId: 1 }, // Finals = 2
+    ];
+    const tournaments = [{ id: 1, isNeutralSite: true }];
+    const picks = [{ teamId: 1 }, { teamId: 2 }, { teamId: 3 }];
+    expect(calculateEntryScore(picks, bonusTeams, rounds, tournaments)).toBe(14); // 7 + 5 + 2
   });
 });


### PR DESCRIPTION
Add the missing +7 bonus scoring rule: a team that wins its conference championship, is not a top-2 seed, and plays at a neutral site scores 7 points instead of 5. This required adding `seed` to the teams table and `isNeutralSite` to the tournaments table, updating scoring and PPR calculations, threading tournament context through the leaderboard API, and exposing both new fields in the admin UI.